### PR TITLE
Add stream-mode config for OpenAI/Gemini and configurable extra prompt buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,40 @@ To use AskGPT, simply highlight the text that you want to ask a question about, 
 
 ### Available actions
 
+### Configuration
+
+AskGPT now supports a built-in **AskGPT Config** action in the highlight menu. You can configure:
+
+- `openai_stream`: enable/disable OpenAI Chat Completions stream mode.
+- `gemini_stream`: enable/disable Gemini stream mode.
+- `extra_buttons`: define custom highlight-menu buttons with your own prompt templates.
+
+Use `{{highlight}}` inside a custom prompt to inject the selected text.
+
+Example config JSON:
+
+```json
+{
+  "openai_stream": true,
+  "gemini_stream": false,
+  "extra_buttons": [
+    {
+      "id": "simple_explain",
+      "text": "Explain simply",
+      "provider": "openai",
+      "prompt": "Please explain this in easy Traditional Chinese:\n{{highlight}}"
+    },
+    {
+      "id": "key_points",
+      "text": "Key points",
+      "provider": "gemini",
+      "prompt": "List the key points from this excerpt:\n{{highlight}}"
+    }
+  ]
+}
+```
+
+
 - **Ask ChatGPT** – prompt the model with a custom question about the selection.
 - **GPT Dictionary / Gemini Dictionary** – get concise dictionary-style explanations.
 - **GPT Translate** – translate the highlighted passage into Traditional Chinese.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ AskGPT now supports a built-in **AskGPT Config** action in the highlight menu. Y
 
 Use `{{highlight}}` inside a custom prompt to inject the selected text.
 
+When stream mode is enabled, AskGPT opens the result dialog immediately (without the loading popup) and updates the text as partial chunks arrive.
+
 Example config JSON:
 
 ```json

--- a/askdialog.lua
+++ b/askdialog.lua
@@ -86,12 +86,12 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
                   end
                   table.insert(temp_history, { role = "assistant", content = partial })
                   result_text = createResultText(highlightedText, temp_history)
-                  viewer:update(result_text)
+                  chatgpt_viewer = viewer:update(result_text)
                 end,
               } or nil)
               table.insert(message_history, { role = "assistant", content = answer })
               result_text = createResultText(highlightedText, message_history)
-              viewer:update(result_text)
+              chatgpt_viewer = viewer:update(result_text)
             end
 
             chatgpt_viewer = ChatGPTViewer:new {
@@ -111,13 +111,13 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
                 end
                 table.insert(temp_history, { role = "assistant", content = partial })
                 result_text = createResultText(highlightedText, temp_history)
-                chatgpt_viewer:update(result_text)
+                chatgpt_viewer = chatgpt_viewer:update(result_text)
               end,
             } or nil)
 
             table.insert(message_history, { role = "assistant", content = answer })
             result_text = createResultText(highlightedText, message_history)
-            chatgpt_viewer:update(result_text)
+            chatgpt_viewer = chatgpt_viewer:update(result_text)
           end,
         },
       },

--- a/askdialog.lua
+++ b/askdialog.lua
@@ -2,21 +2,31 @@ local InputDialog = require("ui/widget/inputdialog")
 local ChatGPTViewer = require("chatgptviewer")
 local UIManager = require("ui/uimanager")
 local Event = require("ui/event")
-
 local _ = require("gettext")
 
 local queryChatGPT = require("gpt_query")
+local AskGPTConfig = require("config")
+
+local function createResultText(highlightedText, message_history)
+  local result_text = "\"" .. highlightedText .. "\"\n\n"
+  for i = 3, #message_history do
+    if message_history[i].role == "user" then
+      result_text = result_text .. _("User: ") .. message_history[i].content .. "\n\n"
+    else
+      result_text = result_text .. message_history[i].content .. "\n\n"
+    end
+  end
+  return result_text
+end
 
 local function showChatGPTDialog(ui, highlightedText, message_history)
-  local title, author =
-      ui.document:getProps().title or _("Unknown Title"),
-      ui.document:getProps().authors or _("Unknown Author")
-  local message_history = message_history or {
+  local title = ui.document:getProps().title or _("Unknown Title")
+  local author = ui.document:getProps().authors or _("Unknown Author")
+  message_history = message_history or {
     {
       role = "system",
-      content =
-      "You are an erudite, who is helpful, creative, clever. Answer as concisely as possible and in Traditional Chinese." ..
-      "If there's no instructions, please explain the input in 100 words.",
+      content = "You are an erudite, who is helpful, creative, clever. Answer as concisely as possible and in Traditional Chinese."
+        .. "If there's no instructions, please explain the input in 100 words.",
     },
   }
 
@@ -36,99 +46,78 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
         {
           text = _("Ask"),
           callback = function()
-            local InfoMessage = require("ui/widget/infomessage")
-            local loading = InfoMessage:new {
-              text = _("Loading..."),
-              timeout = 1,
-            }
-            UIManager:show(loading)
+            local use_stream = AskGPTConfig.load().openai_stream
+            if not use_stream then
+              local InfoMessage = require("ui/widget/infomessage")
+              UIManager:show(InfoMessage:new { text = _("Loading..."), timeout = 1 })
+            end
 
-            -- Give context to the question
             local context_message = {
               role = "user",
-              content = "I'm reading something titled '" ..
-                  title ..
-                  "' by " .. author .. ". I have a question about the following highlighted text: " .. highlightedText,
+              content = "I'm reading something titled '" .. title .. "' by " .. author
+                .. ". I have a question about the following highlighted text: " .. highlightedText,
             }
             table.insert(message_history, context_message)
 
-            -- Ask the question
             local question = input_dialog:getInputText()
-            local question_message = {
-              role = "user",
-              content = question,
-            }
-            table.insert(message_history, question_message)
-
-            local answer = queryChatGPT(message_history)
-            -- Save the answer to the message history
-            local answer_message = {
-              role = "assistant",
-              content = answer,
-            }
-
-            table.insert(message_history, answer_message)
+            table.insert(message_history, { role = "user", content = question })
             UIManager:close(input_dialog)
-            local result_text = _("Highlighted text: ") .. "\"" .. highlightedText .. "\"" ..
-                "\n\n" .. _("User: ") .. question ..
-                "\n\n" .. _("ChatGPT: ") .. answer .. "\n\n"
 
-            local function createResultText(highlightedText, message_history)
-              local result_text = "\"" .. highlightedText .. "\"\n\n"
-
-              for i = 3, #message_history do
-                if message_history[i].role == "user" then
-                  result_text = result_text .. _("User: ") .. message_history[i].content .. "\n\n"
-                else
-                  result_text = result_text .. message_history[i].content .. "\n\n"
-                end
-              end
-
-              return result_text
-            end
-
-
-            local function handleNewQuestion(chatgpt_viewer, question)
-              -- Add the new question to the message history
-              table.insert(message_history, { role = "user", content = question })
-
-              -- Send the query to ChatGPT with the updated message_history
-              local answer = queryChatGPT(message_history)
-
-              -- Add the answer to the message history
-              table.insert(message_history, { role = "assistant", content = answer })
-
-              -- Update the result text
-              result_text = createResultText(highlightedText, message_history)
-
-              -- Update the text and refresh the viewer
-              chatgpt_viewer:update(result_text)
-            end
-
-            local chatgpt_viewer = nil
+            local result_text = _("Loading...")
+            local chatgpt_viewer
 
             local function handleAddToNote()
-              -- ui.highlight:addNote(result_text)
               local index = ui.highlight:saveHighlight(true)
               local a = ui.annotation.annotations[index]
               a.note = result_text
-              ui:handleEvent(Event:new("AnnotationsModified",
-                                    { a, nb_highlights_added = -1, nb_notes_added = 1 }))
+              ui:handleEvent(Event:new("AnnotationsModified", { a, nb_highlights_added = -1, nb_notes_added = 1 }))
 
               UIManager:close(chatgpt_viewer)
               ui.highlight:onClose()
             end
 
+            local function handleNewQuestion(viewer, followup_question)
+              table.insert(message_history, { role = "user", content = followup_question })
+              local answer = queryChatGPT(message_history, AskGPTConfig.load().openai_stream and {
+                on_delta = function(partial)
+                  local temp_history = {}
+                  for i = 1, #message_history do
+                    temp_history[i] = message_history[i]
+                  end
+                  table.insert(temp_history, { role = "assistant", content = partial })
+                  result_text = createResultText(highlightedText, temp_history)
+                  viewer:update(result_text)
+                end,
+              } or nil)
+              table.insert(message_history, { role = "assistant", content = answer })
+              result_text = createResultText(highlightedText, message_history)
+              viewer:update(result_text)
+            end
 
             chatgpt_viewer = ChatGPTViewer:new {
               ui = ui,
               title = _("AskGPT"),
               text = result_text,
-              onAskQuestion = handleNewQuestion, -- Pass the callback function
+              onAskQuestion = handleNewQuestion,
               onAddToNote = handleAddToNote,
             }
-
             UIManager:show(chatgpt_viewer)
+
+            local answer = queryChatGPT(message_history, use_stream and {
+              on_delta = function(partial)
+                local temp_history = {}
+                for i = 1, #message_history do
+                  temp_history[i] = message_history[i]
+                end
+                table.insert(temp_history, { role = "assistant", content = partial })
+                result_text = createResultText(highlightedText, temp_history)
+                chatgpt_viewer:update(result_text)
+              end,
+            } or nil)
+
+            table.insert(message_history, { role = "assistant", content = answer })
+            result_text = createResultText(highlightedText, message_history)
+            chatgpt_viewer:update(result_text)
           end,
         },
       },

--- a/chatgptviewer.lua
+++ b/chatgptviewer.lua
@@ -474,7 +474,35 @@ function ChatGPTViewer:handleTextSelection(text, hold_duration, start_idx, end_i
 end
 
 function ChatGPTViewer:update(new_text)
-  UIManager:close(self)
+  self.text = new_text
+
+  local updated = false
+  if self.scroll_text_w then
+    if type(self.scroll_text_w.setText) == "function" then
+      self.scroll_text_w:setText(new_text)
+      updated = true
+    elseif self.scroll_text_w.text_widget and type(self.scroll_text_w.text_widget.setText) == "function" then
+      self.scroll_text_w.text_widget:setText(new_text)
+      updated = true
+    elseif type(self.scroll_text_w.update) == "function" then
+      self.scroll_text_w:update(new_text)
+      updated = true
+    end
+  end
+
+  if updated then
+    if self.scroll_text_w and type(self.scroll_text_w.scrollToBottom) == "function" then
+      self.scroll_text_w:scrollToBottom()
+    end
+    UIManager:setDirty(self, function()
+      return "partial", self.frame.dimen
+    end)
+    return self
+  end
+
+  local target = self._active_viewer or self
+  UIManager:close(target)
+
   local updated_viewer = ChatGPTViewer:new {
     title = self.title,
     text = new_text,
@@ -484,9 +512,15 @@ function ChatGPTViewer:update(new_text)
     buttons_table = self.buttons_table,
     onAskQuestion = self.onAskQuestion,
     onAddToNote = self.onAddToNote,
+    ui = self.ui,
   }
-  updated_viewer.scroll_text_w:scrollToBottom()
+  self._active_viewer = updated_viewer
+  updated_viewer._active_viewer = updated_viewer
+  if updated_viewer.scroll_text_w and type(updated_viewer.scroll_text_w.scrollToBottom) == "function" then
+    updated_viewer.scroll_text_w:scrollToBottom()
+  end
   UIManager:show(updated_viewer)
+  return updated_viewer
 end
 
 return ChatGPTViewer

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,98 @@
+local json = require("json")
+
+local DEFAULTS = {
+  openai_stream = false,
+  gemini_stream = false,
+  extra_buttons = {},
+}
+
+local function getConfigPath()
+  local ok, DataStorage = pcall(require, "datastorage")
+  if ok and DataStorage and DataStorage.getDataDir then
+    return DataStorage:getDataDir() .. "/askgpt_config.json"
+  end
+  return "askgpt_config.json"
+end
+
+local function shallowCopy(tbl)
+  local copied = {}
+  for k, v in pairs(tbl) do
+    copied[k] = v
+  end
+  return copied
+end
+
+local function normalize(config)
+  local merged = shallowCopy(DEFAULTS)
+  if type(config) ~= "table" then
+    return merged
+  end
+  if type(config.openai_stream) == "boolean" then
+    merged.openai_stream = config.openai_stream
+  end
+  if type(config.gemini_stream) == "boolean" then
+    merged.gemini_stream = config.gemini_stream
+  end
+  if type(config.extra_buttons) == "table" then
+    merged.extra_buttons = config.extra_buttons
+  end
+  return merged
+end
+
+local function loadConfig()
+  local path = getConfigPath()
+  local file = io.open(path, "r")
+  if not file then
+    return normalize(nil)
+  end
+
+  local raw = file:read("*a")
+  file:close()
+  local ok, decoded = pcall(json.decode, raw)
+  if not ok then
+    return normalize(nil)
+  end
+
+  return normalize(decoded)
+end
+
+local function saveConfig(config)
+  local normalized = normalize(config)
+  local path = getConfigPath()
+  local file, err = io.open(path, "w")
+  if not file then
+    return nil, err
+  end
+  file:write(json.encode(normalized))
+  file:close()
+  return true
+end
+
+local function getTemplate()
+  return json.encode({
+    openai_stream = false,
+    gemini_stream = false,
+    extra_buttons = {
+      {
+        id = "example_openai",
+        text = "Explain simply",
+        provider = "openai",
+        prompt = "Please explain the following highlight in simple Traditional Chinese:\n{{highlight}}",
+      },
+      {
+        id = "example_gemini",
+        text = "Find key points",
+        provider = "gemini",
+        prompt = "Summarize key points from this highlight:\n{{highlight}}",
+      },
+    },
+  })
+end
+
+return {
+  load = loadConfig,
+  save = saveConfig,
+  normalize = normalize,
+  template = getTemplate,
+  path = getConfigPath,
+}

--- a/configdialog.lua
+++ b/configdialog.lua
@@ -1,0 +1,68 @@
+local InputDialog = require("ui/widget/inputdialog")
+local UIManager = require("ui/uimanager")
+local InfoMessage = require("ui/widget/infomessage")
+local _ = require("gettext")
+local json = require("json")
+
+local AskGPTConfig = require("config")
+
+local function showMessage(text)
+  UIManager:show(InfoMessage:new {
+    text = text,
+    timeout = 2,
+  })
+end
+
+local function showConfigDialog(onSaved)
+  local current = AskGPTConfig.load()
+  local hint = _("Edit AskGPT config JSON. Use extra_buttons with id/text/provider/prompt. Use {{highlight}} in prompts.")
+
+  local input_dialog
+  input_dialog = InputDialog:new {
+    title = _("AskGPT Config"),
+    input = json.encode(current),
+    input_hint = hint,
+    buttons = {
+      {
+        {
+          text = _("Template"),
+          callback = function()
+            input_dialog:setInputText(AskGPTConfig.template())
+          end,
+        },
+        {
+          text = _("Cancel"),
+          callback = function()
+            UIManager:close(input_dialog)
+          end,
+        },
+        {
+          text = _("Save"),
+          callback = function()
+            local raw = input_dialog:getInputText()
+            local ok, parsed = pcall(json.decode, raw)
+            if not ok or type(parsed) ~= "table" then
+              showMessage(_("Invalid JSON. Config not saved."))
+              return
+            end
+            local success, err = AskGPTConfig.save(parsed)
+            if not success then
+              showMessage(_("Failed to save config: ") .. tostring(err))
+              return
+            end
+            showMessage(_("AskGPT config saved."))
+            UIManager:close(input_dialog)
+            if onSaved then
+              onSaved()
+            end
+          end,
+        },
+      },
+    },
+  }
+
+  UIManager:show(input_dialog)
+  input_dialog:onShowKeyboard()
+end
+
+return showConfigDialog

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -1,62 +1,41 @@
-local InputDialog = require("ui/widget/inputdialog")
 local ChatGPTViewer = require("chatgptviewer")
 local UIManager = require("ui/uimanager")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local PROMPTS = require("prompts")
 local _ = require("gettext")
-
 local Event = require("ui/event")
 
 local queryChatGPT = require("gpt_query")
+local AskGPTConfig = require("config")
 
 local function showChatGPTDialog(ui, highlightedText, message_history)
-  local title, author =
-      ui.document:getProps().title or _("Unknown Title"),
-      ui.document:getProps().authors or _("Unknown Author")
-  local message_history = message_history or {
+  message_history = message_history or {
     {
       role = "system",
-      content =
-      "You are a dictionary with high quality detail vocabulary definitions and examples.",
+      content = "You are a dictionary with high quality detail vocabulary definitions and examples.",
     },
   }
-  prev_context, next_context = ui.highlight:getSelectedWordContext(10)
-  -- Give context to the question
+
+  local prev_context, next_context = ui.highlight:getSelectedWordContext(10)
   local context_message = {
     role = "user",
-    content = 
-        prev_context .. "<<" .. highlightedText .. ">>" .. next_context .. "\n" ..
-        PROMPTS.dict
+    content = prev_context .. "<<" .. highlightedText .. ">>" .. next_context .. "\n" .. PROMPTS.dict,
   }
   table.insert(message_history, context_message)
 
-  local answer = queryChatGPT(message_history)
-  local function createResultText(highlightedText, answer)
-    local result_text = 
-      TextBoxWidget.PTF_HEADER ..  answer
-
-    return result_text
+  local function createResultText(answer)
+    return TextBoxWidget.PTF_HEADER .. (answer or "")
   end
 
-  local result_text = createResultText(highlightedText, answer)
-
-  local function handleNewQuestion(chatgpt_viewer, question)
-    local answer = queryChatGPT(message_history)
-    result_text = createResultText(highlightedText, answer)
-
-    -- Update the text and refresh the viewer
-    chatgpt_viewer:update(result_text)
-  end
-
-  local chatgpt_viewer = nil
+  local use_stream = AskGPTConfig.load().openai_stream
+  local result_text = createResultText("")
+  local chatgpt_viewer
 
   local function handleAddToNote()
-    -- ui.highlight:addNote(answer)
     local index = ui.highlight:saveHighlight(true)
     local a = ui.annotation.annotations[index]
     a.note = result_text
-    ui:handleEvent(Event:new("AnnotationsModified",
-                          { a, nb_highlights_added = -1, nb_notes_added = 1 }))
+    ui:handleEvent(Event:new("AnnotationsModified", { a, nb_highlights_added = -1, nb_notes_added = 1 }))
 
     UIManager:close(chatgpt_viewer)
     ui.highlight:onClose()
@@ -67,11 +46,19 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
     title = _("GPT Dictionary"),
     text = result_text,
     showAskQuestion = false,
-    onAskQuestion = handleNewQuestion, -- Pass the callback function
     onAddToNote = handleAddToNote,
   }
-
   UIManager:show(chatgpt_viewer)
+
+  local answer = queryChatGPT(message_history, use_stream and {
+    on_delta = function(partial)
+      result_text = createResultText(partial)
+      chatgpt_viewer:update(result_text)
+    end,
+  } or nil)
+
+  result_text = createResultText(answer)
+  chatgpt_viewer:update(result_text)
 end
 
 return showChatGPTDialog

--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -53,12 +53,12 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
   local answer = queryChatGPT(message_history, use_stream and {
     on_delta = function(partial)
       result_text = createResultText(partial)
-      chatgpt_viewer:update(result_text)
+      chatgpt_viewer = chatgpt_viewer:update(result_text)
     end,
   } or nil)
 
   result_text = createResultText(answer)
-  chatgpt_viewer:update(result_text)
+  chatgpt_viewer = chatgpt_viewer:update(result_text)
 end
 
 return showChatGPTDialog

--- a/extra_prompt_dialog.lua
+++ b/extra_prompt_dialog.lua
@@ -5,30 +5,13 @@ local _ = require("gettext")
 
 local queryChatGPT = require("gpt_query")
 local queryGemini = require("gemini_query")
-
-local function runPrompt(provider, prompt)
-  if provider == "gemini" then
-    return queryGemini(prompt)
-  end
-
-  return queryChatGPT({
-    {
-      role = "system",
-      content = "You are helpful, concise, and answer in Traditional Chinese unless asked otherwise.",
-    },
-    {
-      role = "user",
-      content = prompt,
-    },
-  })
-end
+local AskGPTConfig = require("config")
 
 local function showExtraPromptDialog(ui, highlightedText, button_config)
   local prompt_template = button_config.prompt or "{{highlight}}"
   local final_prompt = prompt_template:gsub("{{highlight}}", highlightedText)
 
-  local answer = runPrompt(button_config.provider, final_prompt)
-  local result_text = answer
+  local result_text = _("Loading...")
   local viewer
 
   local function handleAddToNote()
@@ -48,8 +31,38 @@ local function showExtraPromptDialog(ui, highlightedText, button_config)
     showAskQuestion = false,
     onAddToNote = handleAddToNote,
   }
-
   UIManager:show(viewer)
+
+  if button_config.provider == "gemini" then
+    local answer = queryGemini(final_prompt, AskGPTConfig.load().gemini_stream and {
+      on_delta = function(partial)
+        result_text = partial
+        viewer:update(result_text)
+      end,
+    } or nil)
+    result_text = answer
+    viewer:update(result_text)
+    return
+  end
+
+  local answer = queryChatGPT({
+    {
+      role = "system",
+      content = "You are helpful, concise, and answer in Traditional Chinese unless asked otherwise.",
+    },
+    {
+      role = "user",
+      content = final_prompt,
+    },
+  }, AskGPTConfig.load().openai_stream and {
+    on_delta = function(partial)
+      result_text = partial
+      viewer:update(result_text)
+    end,
+  } or nil)
+
+  result_text = answer
+  viewer:update(result_text)
 end
 
 return showExtraPromptDialog

--- a/extra_prompt_dialog.lua
+++ b/extra_prompt_dialog.lua
@@ -1,0 +1,55 @@
+local ChatGPTViewer = require("chatgptviewer")
+local UIManager = require("ui/uimanager")
+local Event = require("ui/event")
+local _ = require("gettext")
+
+local queryChatGPT = require("gpt_query")
+local queryGemini = require("gemini_query")
+
+local function runPrompt(provider, prompt)
+  if provider == "gemini" then
+    return queryGemini(prompt)
+  end
+
+  return queryChatGPT({
+    {
+      role = "system",
+      content = "You are helpful, concise, and answer in Traditional Chinese unless asked otherwise.",
+    },
+    {
+      role = "user",
+      content = prompt,
+    },
+  })
+end
+
+local function showExtraPromptDialog(ui, highlightedText, button_config)
+  local prompt_template = button_config.prompt or "{{highlight}}"
+  local final_prompt = prompt_template:gsub("{{highlight}}", highlightedText)
+
+  local answer = runPrompt(button_config.provider, final_prompt)
+  local result_text = answer
+  local viewer
+
+  local function handleAddToNote()
+    local index = ui.highlight:saveHighlight(true)
+    local a = ui.annotation.annotations[index]
+    a.note = result_text
+    ui:handleEvent(Event:new("AnnotationsModified", { a, nb_highlights_added = -1, nb_notes_added = 1 }))
+
+    UIManager:close(viewer)
+    ui.highlight:onClose()
+  end
+
+  viewer = ChatGPTViewer:new {
+    ui = ui,
+    title = button_config.text or _("AskGPT Custom"),
+    text = result_text,
+    showAskQuestion = false,
+    onAddToNote = handleAddToNote,
+  }
+
+  UIManager:show(viewer)
+end
+
+return showExtraPromptDialog

--- a/extra_prompt_dialog.lua
+++ b/extra_prompt_dialog.lua
@@ -37,11 +37,11 @@ local function showExtraPromptDialog(ui, highlightedText, button_config)
     local answer = queryGemini(final_prompt, AskGPTConfig.load().gemini_stream and {
       on_delta = function(partial)
         result_text = partial
-        viewer:update(result_text)
+        viewer = viewer:update(result_text)
       end,
     } or nil)
     result_text = answer
-    viewer:update(result_text)
+    viewer = viewer:update(result_text)
     return
   end
 
@@ -57,12 +57,12 @@ local function showExtraPromptDialog(ui, highlightedText, button_config)
   }, AskGPTConfig.load().openai_stream and {
     on_delta = function(partial)
       result_text = partial
-      viewer:update(result_text)
+      viewer = viewer:update(result_text)
     end,
   } or nil)
 
   result_text = answer
-  viewer:update(result_text)
+  viewer = viewer:update(result_text)
 end
 
 return showExtraPromptDialog

--- a/gemini_dictdialog.lua
+++ b/gemini_dictdialog.lua
@@ -42,12 +42,12 @@ local function showGeminiDictDialog(ui, highlightedText)
   local answer = queryGemini(context_message, use_stream and {
     on_delta = function(partial)
       result_text = createResultText(partial)
-      chatgpt_viewer:update(result_text)
+      chatgpt_viewer = chatgpt_viewer:update(result_text)
     end,
   } or nil)
 
   result_text = createResultText(answer)
-  chatgpt_viewer:update(result_text)
+  chatgpt_viewer = chatgpt_viewer:update(result_text)
 end
 
 return showGeminiDictDialog

--- a/gemini_dictdialog.lua
+++ b/gemini_dictdialog.lua
@@ -1,4 +1,3 @@
-local InputDialog = require("ui/widget/inputdialog")
 local ChatGPTViewer = require("chatgptviewer")
 local UIManager = require("ui/uimanager")
 local TextBoxWidget = require("ui/widget/textboxwidget")
@@ -7,48 +6,25 @@ local _ = require("gettext")
 local Event = require("ui/event")
 
 local queryGemini = require("gemini_query")
+local AskGPTConfig = require("config")
 
-local function showGeminiDictDialog(ui, highlightedText, message_history)
-  prev_context, next_context = ui.highlight:getSelectedWordContext(10)
+local function showGeminiDictDialog(ui, highlightedText)
+  local prev_context, next_context = ui.highlight:getSelectedWordContext(10)
+  local context_message = prev_context .. "<<" .. highlightedText .. ">>" .. next_context .. "\n" .. PROMPTS.dict
 
-  local context_message = prev_context .. "<<" .. highlightedText .. ">>" .. next_context .. "\n" ..
-        PROMPTS.dict
-
-  local success, result = pcall(function()
-    return queryGemini(context_message)
-  end)
-  if success then
-    answer = result
-  else
-    answer = "Error: " .. result
+  local function createResultText(answer)
+    return TextBoxWidget.PTF_HEADER .. (answer or "")
   end
 
-  local function createResultText(highlightedText, answer)
-    local result_text = 
-      TextBoxWidget.PTF_HEADER ..  answer
-
-    return result_text
-  end
-
-  local result_text = createResultText(highlightedText, answer)
-
-  local function handleNewQuestion(chatgpt_viewer, question)
-    local answer = queryGemini(context_message)
-    result_text = createResultText(highlightedText, answer)
-
-    -- Update the text and refresh the viewer
-    chatgpt_viewer:update(result_text)
-  end
-
-  local chatgpt_viewer = nil
+  local use_stream = AskGPTConfig.load().gemini_stream
+  local result_text = createResultText("")
+  local chatgpt_viewer
 
   local function handleAddToNote()
-    -- ui.highlight:addNote(answer)
     local index = ui.highlight:saveHighlight(true)
     local a = ui.annotation.annotations[index]
     a.note = result_text
-    ui:handleEvent(Event:new("AnnotationsModified",
-                          { a, nb_highlights_added = -1, nb_notes_added = 1 }))
+    ui:handleEvent(Event:new("AnnotationsModified", { a, nb_highlights_added = -1, nb_notes_added = 1 }))
 
     UIManager:close(chatgpt_viewer)
     ui.highlight:onClose()
@@ -59,11 +35,19 @@ local function showGeminiDictDialog(ui, highlightedText, message_history)
     title = _("Gemini Dictionary"),
     text = result_text,
     showAskQuestion = false,
-    onAskQuestion = handleNewQuestion, -- Pass the callback function
     onAddToNote = handleAddToNote,
   }
-
   UIManager:show(chatgpt_viewer)
+
+  local answer = queryGemini(context_message, use_stream and {
+    on_delta = function(partial)
+      result_text = createResultText(partial)
+      chatgpt_viewer:update(result_text)
+    end,
+  } or nil)
+
+  result_text = createResultText(answer)
+  chatgpt_viewer:update(result_text)
 end
 
 return showGeminiDictDialog

--- a/gemini_query.lua
+++ b/gemini_query.lua
@@ -18,15 +18,24 @@ local function extractGeminiText(candidate)
   return table.concat(parts)
 end
 
+local function decodeGeminiDelta(payload)
+  if payload == "[DONE]" then
+    return nil
+  end
+  local ok, decoded = pcall(json.decode, payload)
+  if not ok or not decoded or not decoded.candidates or not decoded.candidates[1] then
+    return nil
+  end
+  return extractGeminiText(decoded.candidates[1])
+end
+
 local function parseGeminiStream(raw)
   local pieces = {}
   for line in raw:gmatch("[^\r\n]+") do
     local payload = line:match("^data:%s*(.+)$")
-    if payload and payload ~= "[DONE]" then
-      local ok, decoded = pcall(json.decode, payload)
-      if ok and decoded and decoded.candidates and decoded.candidates[1] then
-        table.insert(pieces, extractGeminiText(decoded.candidates[1]))
-      end
+    local delta = payload and decodeGeminiDelta(payload) or nil
+    if delta and delta ~= "" then
+      table.insert(pieces, delta)
     end
   end
   return table.concat(pieces)
@@ -40,11 +49,11 @@ local function queryGemini(context_message, opts)
     use_stream = config.gemini_stream
   end
 
-  local method_name = use_stream and "streamGenerateContent?alt=sse" or "generateContent"
-  local api_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:"
-    .. method_name .. "&key=" .. API_KEY.key
-
-  if not use_stream then
+  local api_url
+  if use_stream then
+    api_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:streamGenerateContent?alt=sse&key="
+      .. API_KEY.key
+  else
     api_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent?key=" .. API_KEY.key
   end
 
@@ -71,8 +80,48 @@ local function queryGemini(context_message, opts)
   }
 
   local requestBody = json.encode(data)
-
   local responseBody = {}
+
+  if use_stream and opts.on_delta then
+    local partial = ""
+    local pending = ""
+    local stream_sink = function(chunk)
+      if not chunk then
+        return 1
+      end
+      table.insert(responseBody, chunk)
+      pending = pending .. chunk
+      while true do
+        local line_end = pending:find("\n", 1, true)
+        if not line_end then
+          break
+        end
+        local line = pending:sub(1, line_end - 1):gsub("\r$", "")
+        pending = pending:sub(line_end + 1)
+        local payload = line:match("^data:%s*(.+)$")
+        local delta = payload and decodeGeminiDelta(payload) or nil
+        if delta and delta ~= "" then
+          partial = partial .. delta
+          opts.on_delta(partial)
+        end
+      end
+      return 1
+    end
+
+    local _, code = https.request {
+      url = api_url,
+      method = "POST",
+      headers = headers,
+      source = ltn12.source.string(requestBody),
+      sink = stream_sink,
+    }
+
+    if code ~= 200 then
+      return "Error querying Gemini API: " .. tostring(code)
+    end
+
+    return partial ~= "" and partial or parseGeminiStream(table.concat(responseBody))
+  end
 
   local _, code = https.request {
     url = api_url,

--- a/gemini_query.lua
+++ b/gemini_query.lua
@@ -2,10 +2,51 @@ local API_KEY = require("gemini_api_key")
 local https = require("ssl.https")
 local ltn12 = require("ltn12")
 local json = require("json")
+local AskGPTConfig = require("config")
 
+local function extractGeminiText(candidate)
+  if not candidate or not candidate.content or not candidate.content.parts then
+    return ""
+  end
 
-local function queryGemini(context_message)
-  local api_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent?key=" .. API_KEY.key
+  local parts = {}
+  for _, part in ipairs(candidate.content.parts) do
+    if part.text then
+      table.insert(parts, part.text)
+    end
+  end
+  return table.concat(parts)
+end
+
+local function parseGeminiStream(raw)
+  local pieces = {}
+  for line in raw:gmatch("[^\r\n]+") do
+    local payload = line:match("^data:%s*(.+)$")
+    if payload and payload ~= "[DONE]" then
+      local ok, decoded = pcall(json.decode, payload)
+      if ok and decoded and decoded.candidates and decoded.candidates[1] then
+        table.insert(pieces, extractGeminiText(decoded.candidates[1]))
+      end
+    end
+  end
+  return table.concat(pieces)
+end
+
+local function queryGemini(context_message, opts)
+  opts = opts or {}
+  local config = AskGPTConfig.load()
+  local use_stream = opts.stream
+  if use_stream == nil then
+    use_stream = config.gemini_stream
+  end
+
+  local method_name = use_stream and "streamGenerateContent?alt=sse" or "generateContent"
+  local api_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:"
+    .. method_name .. "&key=" .. API_KEY.key
+
+  if not use_stream then
+    api_url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent?key=" .. API_KEY.key
+  end
 
   local headers = {
     ["Content-Type"] = "application/json",
@@ -13,25 +54,27 @@ local function queryGemini(context_message)
 
   local data = {
     contents = {
-        {
-            parts = {{ 
-              text = context_message ,
-            }}
-        }
+      {
+        parts = {
+          {
+            text = context_message,
+          },
+        },
+      },
     },
     safety_settings = {
       { category = "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold = "BLOCK_NONE" },
       { category = "HARM_CATEGORY_HATE_SPEECH", threshold = "BLOCK_NONE" },
       { category = "HARM_CATEGORY_HARASSMENT", threshold = "BLOCK_NONE" },
-      { category = "HARM_CATEGORY_DANGEROUS_CONTENT", threshold = "BLOCK_NONE" }
-    }
+      { category = "HARM_CATEGORY_DANGEROUS_CONTENT", threshold = "BLOCK_NONE" },
+    },
   }
 
   local requestBody = json.encode(data)
 
   local responseBody = {}
 
-  local res, code, responseHeaders = https.request {
+  local _, code = https.request {
     url = api_url,
     method = "POST",
     headers = headers,
@@ -40,12 +83,16 @@ local function queryGemini(context_message)
   }
 
   if code ~= 200 then
-    return "Error querying Gemini API: " .. code
+    return "Error querying Gemini API: " .. tostring(code)
   end
 
-  local response = json.decode(table.concat(responseBody))
-  return response.candidates[1].content.parts[1].text
-  -- return table.concat(responseBody)
+  local raw = table.concat(responseBody)
+  if use_stream then
+    return parseGeminiStream(raw)
+  end
+
+  local response = json.decode(raw)
+  return extractGeminiText(response.candidates[1])
 end
 
 return queryGemini

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -2,10 +2,35 @@ local API_KEY = require("api_key")
 local https = require("ssl.https")
 local ltn12 = require("ltn12")
 local json = require("json")
+local AskGPTConfig = require("config")
 
-local function queryChatGPT(message_history)
+local function parseOpenAIStream(raw)
+  local pieces = {}
+  for line in raw:gmatch("[^\r\n]+") do
+    local payload = line:match("^data:%s*(.+)$")
+    if payload and payload ~= "[DONE]" then
+      local ok, decoded = pcall(json.decode, payload)
+      if ok and decoded and decoded.choices and decoded.choices[1] and decoded.choices[1].delta then
+        local delta = decoded.choices[1].delta.content
+        if delta then
+          table.insert(pieces, delta)
+        end
+      end
+    end
+  end
+  return table.concat(pieces)
+end
+
+local function queryChatGPT(message_history, opts)
+  opts = opts or {}
   local api_key = API_KEY.key
   local api_url = "https://api.openai.com/v1/chat/completions"
+
+  local config = AskGPTConfig.load()
+  local use_stream = opts.stream
+  if use_stream == nil then
+    use_stream = config.openai_stream
+  end
 
   local headers = {
     ["Content-Type"] = "application/json",
@@ -13,13 +38,14 @@ local function queryChatGPT(message_history)
   }
 
   local requestBody = json.encode({
-    model = "gpt-4.1-mini",
+    model = opts.model or "gpt-4.1-mini",
     messages = message_history,
+    stream = use_stream,
   })
 
   local responseBody = {}
 
-  local res, code, responseHeaders = https.request {
+  local _, code = https.request {
     url = api_url,
     method = "POST",
     headers = headers,
@@ -28,10 +54,15 @@ local function queryChatGPT(message_history)
   }
 
   if code ~= 200 then
-    error("Error querying ChatGPT API: " .. code)
+    error("Error querying ChatGPT API: " .. tostring(code))
   end
 
-  local response = json.decode(table.concat(responseBody))
+  local raw = table.concat(responseBody)
+  if use_stream then
+    return parseOpenAIStream(raw)
+  end
+
+  local response = json.decode(raw)
   return response.choices[1].message.content
 end
 

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -4,18 +4,25 @@ local ltn12 = require("ltn12")
 local json = require("json")
 local AskGPTConfig = require("config")
 
+local function decodeOpenAIDelta(payload)
+  if payload == "[DONE]" then
+    return nil
+  end
+  local ok, decoded = pcall(json.decode, payload)
+  if not ok or not decoded or not decoded.choices or not decoded.choices[1] then
+    return nil
+  end
+  local delta = decoded.choices[1].delta
+  return delta and delta.content or nil
+end
+
 local function parseOpenAIStream(raw)
   local pieces = {}
   for line in raw:gmatch("[^\r\n]+") do
     local payload = line:match("^data:%s*(.+)$")
-    if payload and payload ~= "[DONE]" then
-      local ok, decoded = pcall(json.decode, payload)
-      if ok and decoded and decoded.choices and decoded.choices[1] and decoded.choices[1].delta then
-        local delta = decoded.choices[1].delta.content
-        if delta then
-          table.insert(pieces, delta)
-        end
-      end
+    local delta = payload and decodeOpenAIDelta(payload) or nil
+    if delta then
+      table.insert(pieces, delta)
     end
   end
   return table.concat(pieces)
@@ -44,6 +51,47 @@ local function queryChatGPT(message_history, opts)
   })
 
   local responseBody = {}
+
+  if use_stream and opts.on_delta then
+    local partial = ""
+    local pending = ""
+    local stream_sink = function(chunk)
+      if not chunk then
+        return 1
+      end
+      table.insert(responseBody, chunk)
+      pending = pending .. chunk
+      while true do
+        local line_end = pending:find("\n", 1, true)
+        if not line_end then
+          break
+        end
+        local line = pending:sub(1, line_end - 1):gsub("\r$", "")
+        pending = pending:sub(line_end + 1)
+        local payload = line:match("^data:%s*(.+)$")
+        local delta = payload and decodeOpenAIDelta(payload) or nil
+        if delta then
+          partial = partial .. delta
+          opts.on_delta(partial)
+        end
+      end
+      return 1
+    end
+
+    local _, code = https.request {
+      url = api_url,
+      method = "POST",
+      headers = headers,
+      source = ltn12.source.string(requestBody),
+      sink = stream_sink,
+    }
+
+    if code ~= 200 then
+      error("Error querying ChatGPT API: " .. tostring(code))
+    end
+
+    return partial ~= "" and partial or parseOpenAIStream(table.concat(responseBody))
+  end
 
   local _, code = https.request {
     url = api_url,

--- a/main.lua
+++ b/main.lua
@@ -33,6 +33,14 @@ function showLoadingDialog(highlight_instance)
   UIManager:show(loading)
 end
 
+function isStreamMode(provider)
+  local config = AskGPTConfig.load()
+  if provider == "gemini" then
+    return config.gemini_stream
+  end
+  return config.openai_stream
+end
+
 function checkNetworkStatus()
   if not NetworkMgr:isConnected() then
     UIManager:show(InfoMessage:new {
@@ -59,7 +67,9 @@ function AskGPT:addExtraButtons()
             if not checkNetworkStatus() then
               return
             end
-            showLoadingDialog(_reader_highlight_instance)
+            if not isStreamMode(button.provider) then
+              showLoadingDialog(_reader_highlight_instance)
+            end
             UIManager:scheduleIn(0.1, function()
               showExtraPromptDialog(self.ui, _reader_highlight_instance.selected_text.text, button)
             end)
@@ -97,7 +107,9 @@ function AskGPT:init()
         if not checkNetworkStatus() then
           return
         end
-        showLoadingDialog(_reader_highlight_instance)
+        if not isStreamMode("openai") then
+          showLoadingDialog(_reader_highlight_instance)
+        end
         UIManager:scheduleIn(0.1, function()
           showDictionaryDialog(self.ui, _reader_highlight_instance.selected_text.text)
         end)
@@ -112,7 +124,9 @@ function AskGPT:init()
         if not checkNetworkStatus() then
           return
         end
-        showLoadingDialog(_reader_highlight_instance)
+        if not isStreamMode("gemini") then
+          showLoadingDialog(_reader_highlight_instance)
+        end
         UIManager:scheduleIn(0.1, function()
           showGeminiDictDialog(self.ui, _reader_highlight_instance.selected_text.text)
         end)
@@ -127,7 +141,9 @@ function AskGPT:init()
         if not checkNetworkStatus() then
           return
         end
-        showLoadingDialog(_reader_highlight_instance)
+        if not isStreamMode("openai") then
+          showLoadingDialog(_reader_highlight_instance)
+        end
         UIManager:scheduleIn(0.1, function()
           showSummaryDialog(self.ui, _reader_highlight_instance)
         end)
@@ -142,7 +158,9 @@ function AskGPT:init()
         if not checkNetworkStatus() then
           return
         end
-        showLoadingDialog(_reader_highlight_instance)
+        if not isStreamMode("openai") then
+          showLoadingDialog(_reader_highlight_instance)
+        end
         UIManager:scheduleIn(0.1, function()
           showTranslateDialog(self.ui, _reader_highlight_instance.selected_text.text)
         end)

--- a/main.lua
+++ b/main.lua
@@ -9,8 +9,11 @@ local showChatGPTDialog = require("askdialog")
 local showDictionaryDialog = require("dictdialog")
 local showTranslateDialog = require("translatedialog")
 local showSummaryDialog = require("summarydialog")
+local showConfigDialog = require("configdialog")
 
 local showGeminiDictDialog = require("gemini_dictdialog")
+local showExtraPromptDialog = require("extra_prompt_dialog")
+local AskGPTConfig = require("config")
 
 local AskGPT = InputContainer:new {
   name = "askgpt",
@@ -39,6 +42,32 @@ function checkNetworkStatus()
     return false
   end
   return true
+end
+
+function AskGPT:addExtraButtons()
+  local config = AskGPTConfig.load()
+  local extra_buttons = config.extra_buttons or {}
+
+  for idx, button in ipairs(extra_buttons) do
+    if type(button) == "table" and button.text and button.prompt then
+      local button_id = "askgpt_extra_" .. tostring(button.id or idx)
+      self.ui.highlight:addToHighlightDialog(button_id, function(_reader_highlight_instance)
+        return {
+          text = _(button.text),
+          enabled = Device:hasClipboard(),
+          callback = function()
+            if not checkNetworkStatus() then
+              return
+            end
+            showLoadingDialog(_reader_highlight_instance)
+            UIManager:scheduleIn(0.1, function()
+              showExtraPromptDialog(self.ui, _reader_highlight_instance.selected_text.text, button)
+            end)
+          end,
+        }
+      end)
+    end
+  end
 end
 
 function AskGPT:init()
@@ -120,6 +149,23 @@ function AskGPT:init()
       end,
     }
   end)
+
+  self.ui.highlight:addToHighlightDialog("askgpt_config", function(_reader_highlight_instance)
+    return {
+      text = _("AskGPT Config"),
+      enabled = true,
+      callback = function()
+        showConfigDialog(function()
+          UIManager:show(InfoMessage:new {
+            text = _("Config saved. Reopen book to reload extra buttons."),
+            timeout = 2,
+          })
+        end)
+      end,
+    }
+  end)
+
+  self:addExtraButtons()
 end
 
 return AskGPT

--- a/summarydialog.lua
+++ b/summarydialog.lua
@@ -178,7 +178,7 @@ local function showSummaryDialog(ui, highlight_instance)
         end
         table.insert(temp, { role = "assistant", content = partial })
         result_text = buildResultText(metadata_block, temp)
-        viewer:update(result_text)
+        chatgpt_viewer = viewer:update(result_text)
       end,
     } or nil)
     if not ok_answer then
@@ -188,7 +188,7 @@ local function showSummaryDialog(ui, highlight_instance)
     end
     table.insert(message_history, { role = "assistant", content = answer })
     result_text = buildResultText(metadata_block, message_history)
-    viewer:update(result_text)
+    chatgpt_viewer = viewer:update(result_text)
   end
 
   chatgpt_viewer = ChatGPTViewer:new {
@@ -208,7 +208,7 @@ local function showSummaryDialog(ui, highlight_instance)
       end
       table.insert(temp, { role = "assistant", content = partial })
       result_text = buildResultText(metadata_block, temp)
-      chatgpt_viewer:update(result_text)
+      chatgpt_viewer = chatgpt_viewer:update(result_text)
     end,
   } or nil)
 
@@ -219,7 +219,7 @@ local function showSummaryDialog(ui, highlight_instance)
 
   table.insert(message_history, { role = "assistant", content = summary })
   result_text = buildResultText(metadata_block, message_history)
-  chatgpt_viewer:update(result_text)
+  chatgpt_viewer = chatgpt_viewer:update(result_text)
 end
 
 return showSummaryDialog

--- a/summarydialog.lua
+++ b/summarydialog.lua
@@ -7,6 +7,7 @@ local _ = require("gettext")
 
 local PROMPTS = require("prompts")
 local queryChatGPT = require("gpt_query")
+local AskGPTConfig = require("config")
 
 local MAX_CHAPTER_CHARS = 12000
 
@@ -58,8 +59,7 @@ local function getChapterBounds(ui, anchor)
   if not end_xpointer and ui.document.getPageCount then
     local doc_pages = ui.document:getPageCount()
     if doc_pages then
-      end_xpointer = ui.document:getPageXPointer(doc_pages + 1)
-        or ui.document:getPageXPointer(doc_pages)
+      end_xpointer = ui.document:getPageXPointer(doc_pages + 1) or ui.document:getPageXPointer(doc_pages)
     end
   end
 
@@ -104,9 +104,7 @@ local function buildMetadataText(meta, truncated, chapter_len)
   local header = {}
   table.insert(header, T(_("Chapter: %1"), meta.title))
   table.insert(header, T(_("Pages: %1-%2"), meta.page_start, meta.page_end))
-  table.insert(header, T(_("Captured characters: %1%2"),
-    chapter_len,
-    truncated and _(" (truncated)") or ""))
+  table.insert(header, T(_("Captured characters: %1%2"), chapter_len, truncated and _(" (truncated)") or ""))
   return table.concat(header, "\n")
 end
 
@@ -153,33 +151,18 @@ local function showSummaryDialog(ui, highlight_instance)
   )
 
   local message_history = {
-    {
-      role = "system",
-      content = PROMPTS.chapter_summary,
-    },
-    {
-      role = "user",
-      content = chapter_payload,
-    },
+    { role = "system", content = PROMPTS.chapter_summary },
+    { role = "user", content = chapter_payload },
   }
 
-  local ok, summary = pcall(queryChatGPT, message_history)
-  if not ok then
-    showError(_("Failed to fetch summary."))
-    return
-  end
-
-  table.insert(message_history, { role = "assistant", content = summary })
   local result_text = buildResultText(metadata_block, message_history)
-
   local chatgpt_viewer
 
   local function handleAddToNote()
     local index = ui.highlight:saveHighlight(true)
     local annotation = ui.annotation.annotations[index]
     annotation.note = result_text
-    ui:handleEvent(Event:new("AnnotationsModified",
-      { annotation, nb_highlights_added = -1, nb_notes_added = 1 }))
+    ui:handleEvent(Event:new("AnnotationsModified", { annotation, nb_highlights_added = -1, nb_notes_added = 1 }))
 
     UIManager:close(chatgpt_viewer)
     ui.highlight:onClose()
@@ -187,7 +170,17 @@ local function showSummaryDialog(ui, highlight_instance)
 
   local function handleNewQuestion(viewer, question)
     table.insert(message_history, { role = "user", content = question })
-    local ok_answer, answer = pcall(queryChatGPT, message_history)
+    local ok_answer, answer = pcall(queryChatGPT, message_history, AskGPTConfig.load().openai_stream and {
+      on_delta = function(partial)
+        local temp = {}
+        for i = 1, #message_history do
+          temp[i] = message_history[i]
+        end
+        table.insert(temp, { role = "assistant", content = partial })
+        result_text = buildResultText(metadata_block, temp)
+        viewer:update(result_text)
+      end,
+    } or nil)
     if not ok_answer then
       table.remove(message_history)
       showError(_("Failed to fetch summary."))
@@ -205,8 +198,28 @@ local function showSummaryDialog(ui, highlight_instance)
     onAskQuestion = handleNewQuestion,
     onAddToNote = handleAddToNote,
   }
-
   UIManager:show(chatgpt_viewer)
+
+  local ok, summary = pcall(queryChatGPT, message_history, AskGPTConfig.load().openai_stream and {
+    on_delta = function(partial)
+      local temp = {}
+      for i = 1, #message_history do
+        temp[i] = message_history[i]
+      end
+      table.insert(temp, { role = "assistant", content = partial })
+      result_text = buildResultText(metadata_block, temp)
+      chatgpt_viewer:update(result_text)
+    end,
+  } or nil)
+
+  if not ok then
+    showError(_("Failed to fetch summary."))
+    return
+  end
+
+  table.insert(message_history, { role = "assistant", content = summary })
+  result_text = buildResultText(metadata_block, message_history)
+  chatgpt_viewer:update(result_text)
 end
 
 return showSummaryDialog

--- a/translatedialog.lua
+++ b/translatedialog.lua
@@ -1,93 +1,82 @@
-local InputDialog = require("ui/widget/inputdialog")
 local ChatGPTViewer = require("chatgptviewer")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
-
 local Event = require("ui/event")
 
 local queryChatGPT = require("gpt_query")
+local AskGPTConfig = require("config")
+
+local function createResultText(highlightedText, message_history)
+  local result_text = "\"" .. highlightedText .. "\"\n\n"
+  for i = 3, #message_history do
+    if message_history[i].role == "user" then
+      result_text = result_text .. _("User: ") .. message_history[i].content .. "\n\n"
+    else
+      result_text = result_text .. message_history[i].content .. "\n\n"
+    end
+  end
+  return result_text
+end
 
 local function showChatGPTDialog(ui, highlightedText, message_history)
-  local message_history = message_history or {
+  message_history = message_history or {
     {
       role = "system",
-      content =
-      "You are a good translator.",
+      content = "You are a good translator.",
     },
   }
 
-  -- Give context to the question
-  local context_message = {
+  table.insert(message_history, {
     role = "user",
-    content = "translate content in zh-hant:\n" .. highlightedText
-  }
-  table.insert(message_history, context_message)
+    content = "translate content in zh-hant:\n" .. highlightedText,
+  })
 
-  local answer = queryChatGPT(message_history)
-  -- Save the answer to the message history
-  local answer_message = {
-    role = "assistant",
-    content = answer,
-  }
-
-  table.insert(message_history, answer_message)
-  local result_text = answer
-
-  local function createResultText(highlightedText, message_history)
-    local result_text = "\"" .. highlightedText .. "\"\n\n"
-
-    for i = 3, #message_history do
-      if message_history[i].role == "user" then
-        result_text = result_text .. _("User: ") .. message_history[i].content .. "\n\n"
-      else
-        result_text = result_text .. message_history[i].content .. "\n\n"
-      end
-    end
-
-    return result_text
-  end
-
-
-  local function handleNewQuestion(chatgpt_viewer, question)
-    -- Add the new question to the message history
-    table.insert(message_history, { role = "user", content = question })
-
-    -- Send the query to ChatGPT with the updated message_history
-    local answer = queryChatGPT(message_history)
-
-    -- Add the answer to the message history
-    table.insert(message_history, { role = "assistant", content = answer })
-
-    -- Update the result text
-    local result_text = createResultText(highlightedText, message_history)
-
-    -- Update the text and refresh the viewer
-    chatgpt_viewer:update(result_text)
-  end
-
-  local chatgpt_viewer = nil
+  local result_text = ""
+  local chatgpt_viewer
 
   local function handleAddToNote()
-    -- ui.highlight:addNote(answer)
     local index = ui.highlight:saveHighlight(true)
     local a = ui.annotation.annotations[index]
     a.note = result_text
-    ui:handleEvent(Event:new("AnnotationsModified",
-                          { a, nb_highlights_added = -1, nb_notes_added = 1 }))
+    ui:handleEvent(Event:new("AnnotationsModified", { a, nb_highlights_added = -1, nb_notes_added = 1 }))
 
     UIManager:close(chatgpt_viewer)
     ui.highlight:onClose()
   end
 
+  local function handleNewQuestion(viewer, question)
+    table.insert(message_history, { role = "user", content = question })
+    local answer = queryChatGPT(message_history)
+    table.insert(message_history, { role = "assistant", content = answer })
+    result_text = createResultText(highlightedText, message_history)
+    viewer:update(result_text)
+  end
+
   chatgpt_viewer = ChatGPTViewer:new {
     ui = ui,
     title = _("GPT Translate"),
-    text = result_text,
-    onAskQuestion = handleNewQuestion, -- Pass the callback function
+    text = _("Loading..."),
+    onAskQuestion = handleNewQuestion,
     onAddToNote = handleAddToNote,
   }
-
   UIManager:show(chatgpt_viewer)
+
+  local use_stream = AskGPTConfig.load().openai_stream
+  local answer = queryChatGPT(message_history, use_stream and {
+    on_delta = function(partial)
+      local temp_history = {}
+      for i = 1, #message_history do
+        temp_history[i] = message_history[i]
+      end
+      table.insert(temp_history, { role = "assistant", content = partial })
+      result_text = createResultText(highlightedText, temp_history)
+      chatgpt_viewer:update(result_text)
+    end,
+  } or nil)
+
+  table.insert(message_history, { role = "assistant", content = answer })
+  result_text = createResultText(highlightedText, message_history)
+  chatgpt_viewer:update(result_text)
 end
 
 return showChatGPTDialog

--- a/translatedialog.lua
+++ b/translatedialog.lua
@@ -49,7 +49,7 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
     local answer = queryChatGPT(message_history)
     table.insert(message_history, { role = "assistant", content = answer })
     result_text = createResultText(highlightedText, message_history)
-    viewer:update(result_text)
+    chatgpt_viewer = viewer:update(result_text)
   end
 
   chatgpt_viewer = ChatGPTViewer:new {
@@ -70,13 +70,13 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
       end
       table.insert(temp_history, { role = "assistant", content = partial })
       result_text = createResultText(highlightedText, temp_history)
-      chatgpt_viewer:update(result_text)
+      chatgpt_viewer = chatgpt_viewer:update(result_text)
     end,
   } or nil)
 
   table.insert(message_history, { role = "assistant", content = answer })
   result_text = createResultText(highlightedText, message_history)
-  chatgpt_viewer:update(result_text)
+  chatgpt_viewer = chatgpt_viewer:update(result_text)
 end
 
 return showChatGPTDialog


### PR DESCRIPTION
### Motivation

- Allow the plugin to optionally use streaming responses for both OpenAI and Gemini APIs so users can toggle stream mode per provider.
- Provide a persistent, in-plugin configuration area to store stream toggles and custom highlight-menu buttons.
- Let users add extra highlight actions that run provider-specific prompt templates with the highlighted text injected.

### Description

- Add a persistent config module (`config.lua`) that exposes `openai_stream`, `gemini_stream` and `extra_buttons` with load/save/normalize/template helpers.
- Add `configdialog.lua` to edit and save the AskGPT JSON config from inside the plugin and provide a template payload.
- Update `gpt_query.lua` to read config, optionally include `stream=true` in requests, and parse SSE `data:` chunks into the assembled assistant text.
- Update `gemini_query.lua` to support the streaming endpoint (`streamGenerateContent?alt=sse`) and parse SSE chunks, while preserving non-stream behavior.
- Add `extra_prompt_dialog.lua` to execute configured extra buttons (supports `openai` and `gemini`) and replace `{{highlight}}` in prompt templates with the selected text.
- Wire everything in `main.lua` by adding an **AskGPT Config** action and dynamic registration of configured extra highlight buttons, and update `README.md` with configuration docs and an example JSON.

### Testing

- Attempted Lua syntax validation with `for f in *.lua; do luac -p "$f" || exit 1; done`, which failed because `luac` is not available in this environment.
- No other automated tests were run in this environment; runtime validation should be performed on a KoReader device (open book, use the new **AskGPT Config** action, save config, reopen book to load extra buttons).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b210405e248326b250956ed7f8e61d)